### PR TITLE
test: make tests independent from working directory

### DIFF
--- a/tests/library_analyzer/cli/test_cli.py
+++ b/tests/library_analyzer/cli/test_cli.py
@@ -3,6 +3,7 @@ import subprocess
 
 _project_root = os.path.join(os.path.dirname(__file__), "..", "..", "..")
 
+
 def test_cli_api() -> None:
     subprocess.run(
         [

--- a/tests/library_analyzer/cli/test_cli.py
+++ b/tests/library_analyzer/cli/test_cli.py
@@ -1,5 +1,7 @@
+import os
 import subprocess
 
+_project_root = os.path.join(os.path.dirname(__file__), "..", "..", "..")
 
 def test_cli_api() -> None:
     subprocess.run(
@@ -16,6 +18,7 @@ def test_cli_api() -> None:
             "out",
         ],
         check=True,
+        cwd=_project_root,
     )
 
 
@@ -34,6 +37,7 @@ def test_cli_usages() -> None:
             "out",
         ],
         check=True,
+        cwd=_project_root,
     )
 
 
@@ -52,6 +56,7 @@ def test_cli_annotations() -> None:
             "out/annotations.json",
         ],
         check=True,
+        cwd=_project_root,
     )
 
 
@@ -72,6 +77,7 @@ def test_cli_all() -> None:
             "out",
         ],
         check=True,
+        cwd=_project_root,
     )
 
 
@@ -92,4 +98,5 @@ def test_cli_migration() -> None:
             "out",
         ],
         check=True,
+        cwd=_project_root,
     )

--- a/tests/library_analyzer/processing/annotations/test_generate_annotations.py
+++ b/tests/library_analyzer/processing/annotations/test_generate_annotations.py
@@ -26,15 +26,11 @@ def test_generate_annotations(
 
 
 def read_test_data(subfolder: str) -> tuple[UsageCountStore, API, dict]:
-    api_json_path = os.path.join(
-        os.getcwd(), "tests", "data", subfolder, "api_data.json"
-    )
-    usages_json_path = os.path.join(
-        os.getcwd(), "tests", "data", subfolder, "usage_data.json"
-    )
-    annotations_json_path = os.path.join(
-        os.getcwd(), "tests", "data", subfolder, "annotation_data.json"
-    )
+    data_path = os.path.join(os.path.dirname(__file__), "..", "..", "..", "data", subfolder)
+
+    api_json_path = os.path.join(data_path, "api_data.json")
+    usages_json_path = os.path.join(data_path, "usage_data.json")
+    annotations_json_path = os.path.join(data_path, "annotation_data.json")
 
     with open(api_json_path, "r", encoding="utf-8") as api_file:
         api_json = json.load(api_file)

--- a/tests/library_analyzer/processing/annotations/test_generate_annotations.py
+++ b/tests/library_analyzer/processing/annotations/test_generate_annotations.py
@@ -26,7 +26,9 @@ def test_generate_annotations(
 
 
 def read_test_data(subfolder: str) -> tuple[UsageCountStore, API, dict]:
-    data_path = os.path.join(os.path.dirname(__file__), "..", "..", "..", "data", subfolder)
+    data_path = os.path.join(
+        os.path.dirname(__file__), "..", "..", "..", "data", subfolder
+    )
 
     api_json_path = os.path.join(data_path, "api_data.json")
     usages_json_path = os.path.join(data_path, "usage_data.json")

--- a/tests/migration/test_migration.py
+++ b/tests/migration/test_migration.py
@@ -202,18 +202,10 @@ def test_migrate_all_annotations() -> None:
 def test_migrate_command_and_both_annotation_stores() -> None:
     data_path = os.path.join(os.path.dirname(__file__), "..", "data")
 
-    apiv1_json_path = os.path.join(
-        data_path, "migration", "apiv1_data.json"
-    )
-    apiv2_json_path = os.path.join(
-        data_path, "migration", "apiv2_data.json"
-    )
-    annotationsv1_json_path = os.path.join(
-        data_path, "migration", "annotationv1.json"
-    )
-    annotationsv2_json_path = os.path.join(
-        data_path, "migration", "annotationv2.json"
-    )
+    apiv1_json_path = os.path.join(data_path, "migration", "apiv1_data.json")
+    apiv2_json_path = os.path.join(data_path, "migration", "apiv2_data.json")
+    annotationsv1_json_path = os.path.join(data_path, "migration", "annotationv1.json")
+    annotationsv2_json_path = os.path.join(data_path, "migration", "annotationv2.json")
     unsure_annotationsv2_json_path = os.path.join(
         data_path, "migration", "unsure_annotationv2.json"
     )

--- a/tests/migration/test_migration.py
+++ b/tests/migration/test_migration.py
@@ -200,20 +200,22 @@ def test_migrate_all_annotations() -> None:
 
 
 def test_migrate_command_and_both_annotation_stores() -> None:
+    data_path = os.path.join(os.path.dirname(__file__), "..", "data")
+
     apiv1_json_path = os.path.join(
-        os.getcwd(), "tests", "data", "migration", "apiv1_data.json"
+        data_path, "migration", "apiv1_data.json"
     )
     apiv2_json_path = os.path.join(
-        os.getcwd(), "tests", "data", "migration", "apiv2_data.json"
+        data_path, "migration", "apiv2_data.json"
     )
     annotationsv1_json_path = os.path.join(
-        os.getcwd(), "tests", "data", "migration", "annotationv1.json"
+        data_path, "migration", "annotationv1.json"
     )
     annotationsv2_json_path = os.path.join(
-        os.getcwd(), "tests", "data", "migration", "annotationv2.json"
+        data_path, "migration", "annotationv2.json"
     )
     unsure_annotationsv2_json_path = os.path.join(
-        os.getcwd(), "tests", "data", "migration", "unsure_annotationv2.json"
+        data_path, "migration", "unsure_annotationv2.json"
     )
     with open(apiv1_json_path, "r", encoding="utf-8") as apiv1_file, open(
         apiv2_json_path, "r", encoding="utf-8"


### PR DESCRIPTION
Closes #66.

### Summary of Changes

Make tests independent from working directory, so `pytest` can easily be invoked in any subdirectory of the `tests` folder.
