### PR TITLE
feat: store `full_docstring` of classes and functions again

### DIFF
--- a/src/library_analyzer/processing/api/docstring_parsing/_epydoc_parser.py
+++ b/src/library_analyzer/processing/api/docstring_parsing/_epydoc_parser.py
@@ -28,13 +28,18 @@ class EpydocParser(AbstractDocstringParser):
         docstring = get_full_docstring(class_node)
         docstring_obj = parse_docstring(docstring, style=DocstringStyle.EPYDOC)
 
-        return ClassDocumentation(description=get_description(docstring_obj))
+        return ClassDocumentation(
+            description=get_description(docstring_obj),
+            full_docstring=docstring,
+        )
 
     def get_function_documentation(self, function_node: astroid.FunctionDef) -> FunctionDocumentation:
         docstring = get_full_docstring(function_node)
+        docstring_obj = self.__get_cached_function_numpydoc_string(function_node, docstring)
 
         return FunctionDocumentation(
-            description=get_description(self.__get_cached_function_numpydoc_string(function_node, docstring)),
+            description=get_description(docstring_obj),
+            full_docstring=docstring,
         )
 
     def get_parameter_documentation(

--- a/src/library_analyzer/processing/api/docstring_parsing/_numpydoc_parser.py
+++ b/src/library_analyzer/processing/api/docstring_parsing/_numpydoc_parser.py
@@ -36,13 +36,19 @@ class NumpyDocParser(AbstractDocstringParser):
         docstring = get_full_docstring(class_node)
         docstring_obj = parse_docstring(docstring, style=DocstringStyle.NUMPYDOC)
 
-        return ClassDocumentation(description=get_description(docstring_obj))
+        return ClassDocumentation(
+            description=get_description(docstring_obj),
+            full_docstring=docstring,
+        )
 
     def get_function_documentation(self, function_node: astroid.FunctionDef) -> FunctionDocumentation:
         docstring = get_full_docstring(function_node)
         docstring_obj = self.__get_cached_function_numpydoc_string(function_node, docstring)
 
-        return FunctionDocumentation(description=get_description(docstring_obj))
+        return FunctionDocumentation(
+            description=get_description(docstring_obj),
+            full_docstring=docstring,
+        )
 
     def get_parameter_documentation(
         self,

--- a/src/library_analyzer/processing/api/docstring_parsing/_plaintext_docstring_parser.py
+++ b/src/library_analyzer/processing/api/docstring_parsing/_plaintext_docstring_parser.py
@@ -15,13 +15,19 @@ class PlaintextDocstringParser(AbstractDocstringParser):
     """Parses documentation in any format. Should not be used if there is another parser for the specific format."""
 
     def get_class_documentation(self, class_node: astroid.ClassDef) -> ClassDocumentation:
+        docstring = get_full_docstring(class_node)
+
         return ClassDocumentation(
-            description=get_full_docstring(class_node),
+            description=docstring,
+            full_docstring=docstring,
         )
 
     def get_function_documentation(self, function_node: astroid.FunctionDef) -> FunctionDocumentation:
+        docstring = get_full_docstring(function_node)
+
         return FunctionDocumentation(
-            description=get_full_docstring(function_node),
+            description=docstring,
+            full_docstring=docstring,
         )
 
     def get_parameter_documentation(

--- a/src/library_analyzer/processing/api/model/_documentation.py
+++ b/src/library_analyzer/processing/api/model/_documentation.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 @dataclass(frozen=True)
 class ClassDocumentation:
     description: str = ""
+    full_docstring: str = ""
 
     @staticmethod
     def from_dict(d: dict) -> ClassDocumentation:
@@ -19,6 +20,7 @@ class ClassDocumentation:
 @dataclass(frozen=True)
 class FunctionDocumentation:
     description: str = ""
+    full_docstring: str = ""
 
     @staticmethod
     def from_dict(d: dict) -> FunctionDocumentation:

--- a/tests/library_analyzer/processing/api/docstring_parsing/test_epydoc_parser.py
+++ b/tests/library_analyzer/processing/api/docstring_parsing/test_epydoc_parser.py
@@ -38,11 +38,15 @@ class C:
             class_with_documentation,
             ClassDocumentation(
                 description="Lorem ipsum. Code::\n\npass\n\nDolor sit amet.",
+                full_docstring="Lorem ipsum. Code::\n\n    pass\n\nDolor sit amet.",
             ),
         ),
         (
             class_without_documentation,
-            ClassDocumentation(description=""),
+            ClassDocumentation(
+                description="",
+                full_docstring="",
+            ),
         ),
     ],
     ids=[
@@ -87,11 +91,17 @@ def f():
     [
         (
             function_with_documentation,
-            FunctionDocumentation(description="Lorem ipsum. Code::\n\npass\n\nDolor sit amet."),
+            FunctionDocumentation(
+                description="Lorem ipsum. Code::\n\npass\n\nDolor sit amet.",
+                full_docstring="Lorem ipsum. Code::\n\n    pass\n\nDolor sit amet.",
+            ),
         ),
         (
             function_without_documentation,
-            FunctionDocumentation(description=""),
+            FunctionDocumentation(
+                description="",
+                full_docstring="",
+            ),
         ),
     ],
     ids=[

--- a/tests/library_analyzer/processing/api/docstring_parsing/test_numpydoc_parser.py
+++ b/tests/library_analyzer/processing/api/docstring_parsing/test_numpydoc_parser.py
@@ -38,11 +38,15 @@ class C:
             class_with_documentation,
             ClassDocumentation(
                 description="Lorem ipsum. Code::\n\npass\n\nDolor sit amet.",
+                full_docstring="Lorem ipsum. Code::\n\n    pass\n\nDolor sit amet.",
             ),
         ),
         (
             class_without_documentation,
-            ClassDocumentation(description=""),
+            ClassDocumentation(
+                description="",
+                full_docstring="",
+            ),
         ),
     ],
     ids=[
@@ -87,6 +91,7 @@ def f():
             function_with_documentation,
             FunctionDocumentation(
                 description="Lorem ipsum. Code::\n\npass\n\nDolor sit amet.",
+                full_docstring="Lorem ipsum. Code::\n\n    pass\n\nDolor sit amet.",
             ),
         ),
         (

--- a/tests/library_analyzer/processing/api/docstring_parsing/test_plaintext_docstring_parser.py
+++ b/tests/library_analyzer/processing/api/docstring_parsing/test_plaintext_docstring_parser.py
@@ -41,11 +41,15 @@ class C:
             class_with_documentation,
             ClassDocumentation(
                 description="Lorem ipsum.\n\nDolor sit amet.",
+                full_docstring="Lorem ipsum.\n\nDolor sit amet.",
             ),
         ),
         (
             class_without_documentation,
-            ClassDocumentation(description=""),
+            ClassDocumentation(
+                description="",
+                full_docstring="",
+            ),
         ),
     ],
     ids=[
@@ -88,6 +92,7 @@ def f(p: int):
             function_with_documentation,
             FunctionDocumentation(
                 description="Lorem ipsum.\n\nDolor sit amet.",
+                full_docstring="Lorem ipsum.\n\nDolor sit amet.",
             ),
         ),
         (

--- a/tests/library_analyzer/processing/api/model/test_api.py
+++ b/tests/library_analyzer/processing/api/model/test_api.py
@@ -230,7 +230,7 @@ def test_cut_documentation_from_code(code: str, expected_code: str) -> None:
             results=[],
             is_public=True,
             reexported_by=[],
-            documentation=FunctionDocumentation(""),
+            documentation=FunctionDocumentation(),
             code=code,
         )
     assert api_element.get_formatted_code(cut_documentation=True) == expected_code + "\n"

--- a/tests/migration/annotations/called_after_migration.py
+++ b/tests/migration/annotations/called_after_migration.py
@@ -32,7 +32,7 @@ def migrate_called_after_annotation_data_one_to_one_mapping() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
     functionv1_before = Function(
@@ -43,7 +43,7 @@ def migrate_called_after_annotation_data_one_to_one_mapping() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
     functionv2_after = Function(
@@ -54,7 +54,7 @@ def migrate_called_after_annotation_data_one_to_one_mapping() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
     functionv2_before = Function(
@@ -65,7 +65,7 @@ def migrate_called_after_annotation_data_one_to_one_mapping() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
     mapping_after = OneToOneMapping(1.0, functionv1_after, functionv2_after)
@@ -104,7 +104,7 @@ def migrate_called_after_annotation_data_one_to_many_mapping() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
     functionv1_before = Function(
@@ -115,7 +115,7 @@ def migrate_called_after_annotation_data_one_to_many_mapping() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
     functionv2_after_a = Function(
@@ -126,7 +126,7 @@ def migrate_called_after_annotation_data_one_to_many_mapping() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
     functionv2_after_b = Function(
@@ -137,7 +137,7 @@ def migrate_called_after_annotation_data_one_to_many_mapping() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
     functionv2_before = Function(
@@ -148,7 +148,7 @@ def migrate_called_after_annotation_data_one_to_many_mapping() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
     mapping_after = OneToManyMapping(1.0, functionv1_after, [functionv2_after_a, functionv2_after_b])
@@ -199,7 +199,7 @@ def migrate_called_after_annotation_data_one_to_one_mapping__no_mapping_found() 
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
     functionv2_after = Function(
@@ -210,7 +210,7 @@ def migrate_called_after_annotation_data_one_to_one_mapping__no_mapping_found() 
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
     mapping_after = OneToOneMapping(1.0, functionv1_after, functionv2_after)
@@ -248,7 +248,7 @@ def migrate_called_after_annotation_data_one_to_one_mapping__before_splits() -> 
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
     functionv1_before = Function(
@@ -259,7 +259,7 @@ def migrate_called_after_annotation_data_one_to_one_mapping__before_splits() -> 
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
     functionv2_after = Function(
@@ -270,7 +270,7 @@ def migrate_called_after_annotation_data_one_to_one_mapping__before_splits() -> 
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
     functionv2_before_a = Function(
@@ -281,7 +281,7 @@ def migrate_called_after_annotation_data_one_to_one_mapping__before_splits() -> 
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
     functionv2_before_b = Function(
@@ -292,7 +292,7 @@ def migrate_called_after_annotation_data_one_to_one_mapping__before_splits() -> 
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
     mapping_after = OneToOneMapping(1.0, functionv1_after, functionv2_after)
@@ -335,7 +335,7 @@ def migrate_called_after_annotation_data_one_to_many_mapping__two_classes() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
     functionv1_before = Function(
@@ -346,7 +346,7 @@ def migrate_called_after_annotation_data_one_to_many_mapping__two_classes() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
     functionv2_after_a = Function(
@@ -357,7 +357,7 @@ def migrate_called_after_annotation_data_one_to_many_mapping__two_classes() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
     functionv2_after_b = Function(
@@ -368,7 +368,7 @@ def migrate_called_after_annotation_data_one_to_many_mapping__two_classes() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
     functionv2_before_a = Function(
@@ -379,7 +379,7 @@ def migrate_called_after_annotation_data_one_to_many_mapping__two_classes() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
     functionv2_before_b = Function(
@@ -390,7 +390,7 @@ def migrate_called_after_annotation_data_one_to_many_mapping__two_classes() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
     mapping_after = OneToManyMapping(1.0, functionv1_after, [functionv2_after_a, functionv2_after_b])
@@ -441,7 +441,7 @@ def migrate_called_after_annotation_data_duplicated() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
     functionv1_after_2 = Function(
@@ -452,7 +452,7 @@ def migrate_called_after_annotation_data_duplicated() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
     functionv1_before = Function(
@@ -463,7 +463,7 @@ def migrate_called_after_annotation_data_duplicated() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
     functionv2_after = Function(
@@ -474,7 +474,7 @@ def migrate_called_after_annotation_data_duplicated() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
     functionv2_before = Function(
@@ -485,7 +485,7 @@ def migrate_called_after_annotation_data_duplicated() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
     mapping_after = ManyToOneMapping(1.0, [functionv1_after, functionv1_after_2], functionv2_after)

--- a/tests/migration/annotations/description_migration.py
+++ b/tests/migration/annotations/description_migration.py
@@ -40,7 +40,7 @@ def migrate_description_annotation_data_one_to_one_mapping__function() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
 
@@ -52,7 +52,7 @@ def migrate_description_annotation_data_one_to_one_mapping__function() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
 
@@ -91,7 +91,7 @@ def migrate_description_annotation_data_one_to_many_mapping__class() -> (
         superclasses=[],
         is_public=True,
         reexported_by=[],
-        documentation=ClassDocumentation(""),
+        documentation=ClassDocumentation(),
         code="class DescriptionTestClass:\n    pass",
         instance_attributes=[],
     )
@@ -102,7 +102,7 @@ def migrate_description_annotation_data_one_to_many_mapping__class() -> (
         superclasses=[],
         is_public=True,
         reexported_by=[],
-        documentation=ClassDocumentation(""),
+        documentation=ClassDocumentation(),
         code="class NewDescriptionTestClass:\n    pass",
         instance_attributes=[],
     )
@@ -113,7 +113,7 @@ def migrate_description_annotation_data_one_to_many_mapping__class() -> (
         superclasses=[],
         is_public=True,
         reexported_by=[],
-        documentation=ClassDocumentation(""),
+        documentation=ClassDocumentation(),
         code="class NewDescriptionTestClass2:\n    pass",
         instance_attributes=[],
     )
@@ -125,7 +125,7 @@ def migrate_description_annotation_data_one_to_many_mapping__class() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
 
@@ -229,7 +229,7 @@ def migrate_description_annotation_data_duplicated() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
     functionv1_2 = Function(
@@ -240,7 +240,7 @@ def migrate_description_annotation_data_duplicated() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
 
@@ -252,7 +252,7 @@ def migrate_description_annotation_data_duplicated() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
 

--- a/tests/migration/annotations/expert_migration.py
+++ b/tests/migration/annotations/expert_migration.py
@@ -40,7 +40,7 @@ def migrate_expert_annotation_data__function() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
 
@@ -52,7 +52,7 @@ def migrate_expert_annotation_data__function() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
 
@@ -89,7 +89,7 @@ def migrate_expert_annotation_data__class() -> (
         superclasses=[],
         is_public=True,
         reexported_by=[],
-        documentation=ClassDocumentation(""),
+        documentation=ClassDocumentation(),
         code="class ExpertTestClass:\n    pass",
         instance_attributes=[],
     )
@@ -100,7 +100,7 @@ def migrate_expert_annotation_data__class() -> (
         superclasses=[],
         is_public=True,
         reexported_by=[],
-        documentation=ClassDocumentation(""),
+        documentation=ClassDocumentation(),
         code="class NewExpertTestClass:\n    pass",
         instance_attributes=[],
     )
@@ -112,7 +112,7 @@ def migrate_expert_annotation_data__class() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
 
@@ -201,7 +201,7 @@ def migrate_expert_annotation_data_duplicated() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
     functionv1_2 = Function(
@@ -212,7 +212,7 @@ def migrate_expert_annotation_data_duplicated() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
 
@@ -224,7 +224,7 @@ def migrate_expert_annotation_data_duplicated() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
 

--- a/tests/migration/annotations/group_migration.py
+++ b/tests/migration/annotations/group_migration.py
@@ -68,7 +68,7 @@ def migrate_group_annotation_data_one_to_many_mapping() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
 
@@ -107,7 +107,7 @@ def migrate_group_annotation_data_one_to_many_mapping() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
 
@@ -137,7 +137,7 @@ def migrate_group_annotation_data_one_to_many_mapping() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
 
@@ -167,7 +167,7 @@ def migrate_group_annotation_data_one_to_many_mapping() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
     parameterv2_4_b = Parameter(
@@ -187,7 +187,7 @@ def migrate_group_annotation_data_one_to_many_mapping() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
     functionv2_5 = Function(
@@ -198,7 +198,7 @@ def migrate_group_annotation_data_one_to_many_mapping() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
     classv2_6 = Class(
@@ -208,7 +208,7 @@ def migrate_group_annotation_data_one_to_many_mapping() -> (
         superclasses=[],
         is_public=True,
         reexported_by=[],
-        documentation=ClassDocumentation(""),
+        documentation=ClassDocumentation(),
         code="class NewClass:\n    pass",
         instance_attributes=[],
     )
@@ -328,7 +328,7 @@ def migrate_group_annotation_data_one_to_one_mapping() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
     parameterv1_a = Parameter(
@@ -358,7 +358,7 @@ def migrate_group_annotation_data_one_to_one_mapping() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
     parameterv2_a = Parameter(
@@ -423,7 +423,7 @@ def migrate_group_annotation_data_one_to_one_mapping__one_mapping_for_parameters
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
     parameterv1_a = Parameter(
@@ -453,7 +453,7 @@ def migrate_group_annotation_data_one_to_one_mapping__one_mapping_for_parameters
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
     parameterv2_a = Parameter(
@@ -571,7 +571,7 @@ def migrate_group_annotation_data_duplicated() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
     functionv1_2 = Function(
@@ -582,7 +582,7 @@ def migrate_group_annotation_data_duplicated() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
 
@@ -621,7 +621,7 @@ def migrate_group_annotation_data_duplicated() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
 

--- a/tests/migration/annotations/move_migration.py
+++ b/tests/migration/annotations/move_migration.py
@@ -37,7 +37,7 @@ def migrate_move_annotation_data_one_to_one_mapping__global_function() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
 
@@ -49,7 +49,7 @@ def migrate_move_annotation_data_one_to_one_mapping__global_function() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
 
@@ -88,7 +88,7 @@ def migrate_move_annotation_data_one_to_one_mapping__class() -> (
         superclasses=[],
         is_public=True,
         reexported_by=[],
-        documentation=ClassDocumentation(""),
+        documentation=ClassDocumentation(),
         code="class MoveTestClass:\n    pass",
         instance_attributes=[],
     )
@@ -99,7 +99,7 @@ def migrate_move_annotation_data_one_to_one_mapping__class() -> (
         superclasses=[],
         is_public=True,
         reexported_by=[],
-        documentation=ClassDocumentation(""),
+        documentation=ClassDocumentation(),
         code="class NewMoveTestClass:\n    pass",
         instance_attributes=[],
     )
@@ -140,7 +140,7 @@ def migrate_move_annotation_data_one_to_many_mapping() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
 
@@ -152,7 +152,7 @@ def migrate_move_annotation_data_one_to_many_mapping() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
 
@@ -164,7 +164,7 @@ def migrate_move_annotation_data_one_to_many_mapping() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
 
@@ -212,7 +212,7 @@ def migrate_move_annotation_data_one_to_one_mapping_duplicated() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
     functionv1_2 = Function(
@@ -223,7 +223,7 @@ def migrate_move_annotation_data_one_to_one_mapping_duplicated() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
 
@@ -235,7 +235,7 @@ def migrate_move_annotation_data_one_to_one_mapping_duplicated() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
 

--- a/tests/migration/annotations/remove_migration.py
+++ b/tests/migration/annotations/remove_migration.py
@@ -37,7 +37,7 @@ def migrate_remove_annotation_data_one_to_one_mapping() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
 
@@ -49,7 +49,7 @@ def migrate_remove_annotation_data_one_to_one_mapping() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
 
@@ -86,7 +86,7 @@ def migrate_remove_annotation_data_one_to_many_mapping() -> (
         superclasses=[],
         is_public=True,
         reexported_by=[],
-        documentation=ClassDocumentation(""),
+        documentation=ClassDocumentation(),
         code="class RemoveTestClass:\n    pass",
         instance_attributes=[],
     )
@@ -97,7 +97,7 @@ def migrate_remove_annotation_data_one_to_many_mapping() -> (
         superclasses=[],
         is_public=True,
         reexported_by=[],
-        documentation=ClassDocumentation(""),
+        documentation=ClassDocumentation(),
         code="class NewRemoveTestClass:\n    pass",
         instance_attributes=[],
     )
@@ -108,7 +108,7 @@ def migrate_remove_annotation_data_one_to_many_mapping() -> (
         superclasses=[],
         is_public=True,
         reexported_by=[],
-        documentation=ClassDocumentation(""),
+        documentation=ClassDocumentation(),
         code="class NewRemoveTestClass2:\n    pass",
         instance_attributes=[],
     )
@@ -120,7 +120,7 @@ def migrate_remove_annotation_data_one_to_many_mapping() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
 
@@ -173,7 +173,7 @@ def migrate_remove_annotation_data_duplicated() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
     functionv1_2 = Function(
@@ -184,7 +184,7 @@ def migrate_remove_annotation_data_duplicated() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
 
@@ -196,7 +196,7 @@ def migrate_remove_annotation_data_duplicated() -> (
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
 

--- a/tests/migration/annotations/rename_migration.py
+++ b/tests/migration/annotations/rename_migration.py
@@ -109,7 +109,7 @@ def migrate_rename_annotation_data_one_to_many_mapping() -> (
         superclasses=[],
         is_public=True,
         reexported_by=[],
-        documentation=ClassDocumentation(""),
+        documentation=ClassDocumentation(),
         code="class NewClass:\n    pass",
         instance_attributes=[],
     )

--- a/tests/migration/annotations/todo_migration.py
+++ b/tests/migration/annotations/todo_migration.py
@@ -168,7 +168,7 @@ def migrate_todo_annotation_data_many_to_many_mapping() -> tuple[Mapping, Abstra
         superclasses=[],
         is_public=True,
         reexported_by=[],
-        documentation=ClassDocumentation(""),
+        documentation=ClassDocumentation(),
         code="class TestTodoClass:\n    pass",
         instance_attributes=[],
     )

--- a/tests/migration/test_migration.py
+++ b/tests/migration/test_migration.py
@@ -314,7 +314,7 @@ def test_handle_duplicates() -> None:
         superclasses=[],
         is_public=True,
         reexported_by=[],
-        documentation=ClassDocumentation(""),
+        documentation=ClassDocumentation(),
         code="",
         instance_attributes=[],
     )
@@ -395,7 +395,7 @@ def test_was_moved() -> None:
         results=[],
         is_public=True,
         reexported_by=[],
-        documentation=FunctionDocumentation(""),
+        documentation=FunctionDocumentation(),
         code="",
     )
     assert _was_moved(function, function, move_annotation) is False
@@ -410,7 +410,7 @@ def test_was_moved() -> None:
                 results=[],
                 is_public=True,
                 reexported_by=[],
-                documentation=FunctionDocumentation(""),
+                documentation=FunctionDocumentation(),
                 code="",
             ),
             move_annotation,
@@ -428,7 +428,7 @@ def test_was_moved() -> None:
                 results=[],
                 is_public=True,
                 reexported_by=[],
-                documentation=FunctionDocumentation(""),
+                documentation=FunctionDocumentation(),
                 code="",
             ),
             move_annotation,


### PR DESCRIPTION
Closes #83.

### Summary of Changes

Store the full docstring of classes and functions again in the created docstring. This was removed in #82.
