### PR TITLE
feat: store `id` of `Result`s

### DIFF
--- a/src/library_analyzer/processing/api/model/_api.py
+++ b/src/library_analyzer/processing/api/model/_api.py
@@ -499,6 +499,7 @@ class ParameterAssignment(Enum):
 
 @dataclass(frozen=True)
 class Result:
+    id: str
     name: str
     docstring: ResultDocstring
     function_id: str | None = None
@@ -506,13 +507,18 @@ class Result:
     @staticmethod
     def from_dict(d: dict[str, Any], function_id: str | None = None) -> Result:
         return Result(
+            d["id"],
             d["name"],
             ResultDocstring.from_dict(d.get("docstring", {})),
             function_id,
         )
 
     def to_dict(self) -> dict[str, Any]:
-        return {"name": self.name, "docstring": self.docstring.to_dict()}
+        return {
+            "id": self.id,
+            "name": self.name,
+            "docstring": self.docstring.to_dict()
+        }
 
 
 ApiElement: TypeAlias = Module | Class | Attribute | Function | Parameter | Result

--- a/src/library_analyzer/processing/api/model/_api.py
+++ b/src/library_analyzer/processing/api/model/_api.py
@@ -514,11 +514,7 @@ class Result:
         )
 
     def to_dict(self) -> dict[str, Any]:
-        return {
-            "id": self.id,
-            "name": self.name,
-            "docstring": self.docstring.to_dict()
-        }
+        return {"id": self.id, "name": self.name, "docstring": self.docstring.to_dict()}
 
 
 ApiElement: TypeAlias = Module | Class | Attribute | Function | Parameter | Result

--- a/tests/library_analyzer/processing/migration/model/test_differ.py
+++ b/tests/library_analyzer/processing/migration/model/test_differ.py
@@ -213,10 +213,11 @@ def test_parameter_similarity(differ: AbstractDiffer) -> None:
     differ_list,
 )
 def test_result_similarity(differ: AbstractDiffer) -> None:
-    result_a = Result("config", ResultDocstring("dict", ""))
+    result_a = Result("config", "config", ResultDocstring("dict", ""))
     assert differ.compute_result_similarity(result_a, result_a) == 1
 
     result_b = Result(
+        "new_config",
         "new_config",
         ResultDocstring("dict", "A dictionary that includes the new configuration"),
     )

--- a/tests/library_analyzer/processing/migration/model/test_inheritance_differ.py
+++ b/tests/library_analyzer/processing/migration/model/test_inheritance_differ.py
@@ -72,7 +72,7 @@ def create_api_super() -> tuple[API, Class, Class, Attribute, Function, Paramete
         is_public=True,
         docstring=ParameterDocstring("'test_str_a'", "", ""),
     )
-    result_super = Result("config", ResultDocstring("dict", ""), function_id=function_id_super)
+    result_super = Result("config", "config", ResultDocstring("dict", ""), function_id=function_id_super)
     code_function_a = cleandoc(
         """
     def test_function_super(test_parameter: str):
@@ -150,7 +150,7 @@ def create_api_sub() -> tuple[API, Class, Class, Attribute, Function, Parameter,
         is_public=True,
         docstring=ParameterDocstring("'test_str_a'", "", ""),
     )
-    result_sub = Result("config", ResultDocstring("dict", ""), function_id=function_id_sub)
+    result_sub = Result("config", "config", ResultDocstring("dict", ""), function_id=function_id_sub)
     code_function_a = cleandoc(
         """
     def test_function_sub(test_parameter: str):

--- a/tests/library_analyzer/processing/migration/model/test_strict_differ.py
+++ b/tests/library_analyzer/processing/migration/model/test_strict_differ.py
@@ -81,7 +81,7 @@ def test_similarity(differ: AbstractDiffer) -> None:
         is_public=True,
         docstring=ParameterDocstring("'test_str_a'", "", ""),
     )
-    result_a = Result("config", ResultDocstring("dict", ""), function_id=function_id_a)
+    result_a = Result("config", "config", ResultDocstring("dict", ""), function_id=function_id_a)
     code_function_a = cleandoc(
         """
     def test(test_parameter: str):
@@ -124,6 +124,7 @@ def test_similarity(differ: AbstractDiffer) -> None:
         docstring=ParameterDocstring("'test_str_b'", "", ""),
     )
     result_b = Result(
+        "new_config",
         "new_config",
         ResultDocstring("dict", "A dictionary that includes the new configuration"),
         function_id=function_id_b,

--- a/tests/library_analyzer/processing/migration/model/test_unchanged_differ.py
+++ b/tests/library_analyzer/processing/migration/model/test_unchanged_differ.py
@@ -71,7 +71,7 @@ def test_similarity() -> None:
         is_public=True,
         docstring=ParameterDocstring("'test_str_a'", "", ""),
     )
-    result_a = Result("config", ResultDocstring("dict", ""), function_id=function_id_a)
+    result_a = Result("config", "config", ResultDocstring("dict", ""), function_id=function_id_a)
     code_function_a = cleandoc(
         """
     def test(test_parameter: str):
@@ -114,6 +114,7 @@ def test_similarity() -> None:
         docstring=ParameterDocstring("'test_str_b'", "", ""),
     )
     result_b = Result(
+        "new_config",
         "new_config",
         ResultDocstring("dict", "A dictionary that includes the new configuration"),
         function_id=function_id_b,


### PR DESCRIPTION
### Summary of Changes

Store `id` of `Result`s. Now all `ApiElement`s have an `id`.
