### PR TITLE
perf: improve performance of `_get_unmapped_api_elements_as_string`

### DIFF
--- a/src/library_analyzer/processing/migration/_migrate.py
+++ b/src/library_analyzer/processing/migration/_migrate.py
@@ -185,7 +185,6 @@ class Migration:
         print("**Similarity**|**APIV1**|**APIV2**|**comment**\n:-----:|:-----:|:-----:|:----:|")
         table_body = self._get_mappings_for_table()
         table_body.extend(self._get_unmapped_api_elements_for_table(apiv1, apiv2))
-        table_body.sort(key=lambda row: max(len(cell.split("/")) for cell in row.split("|")[:-1]))
         print("\n".join(table_body))
 
     def _handle_duplicates(self) -> None:

--- a/src/library_analyzer/processing/migration/_migrate.py
+++ b/src/library_analyzer/processing/migration/_migrate.py
@@ -146,18 +146,18 @@ class Migration:
             table_rows.append(f"{mapping.similarity:.4}|{apiv1_elements}|{apiv2_elements}|")
         return table_rows
 
-    def _get_not_mapped_api_elements_for_table(self, apiv1: API, apiv2: API) -> list[str]:
-        not_mapped_api_elements: list[str] = []
-        not_mapped_apiv1_elements = self._get_not_mapped_api_elements_as_string(apiv1)
-        for element_id in not_mapped_apiv1_elements:
-            not_mapped_api_elements.append(f"-|`{element_id}`||")
-        not_mapped_apiv2_elements = self._get_not_mapped_api_elements_as_string(apiv2, print_for_apiv2=True)
-        for element_id in not_mapped_apiv2_elements:
-            not_mapped_api_elements.append(f"-||`{element_id}`|")
-        return not_mapped_api_elements
+    def _get_unmapped_api_elements_for_table(self, apiv1: API, apiv2: API) -> list[str]:
+        unmapped_api_elements: list[str] = []
+        unmapped_apiv1_elements = self._get_unmapped_api_elements_as_string(apiv1)
+        for element_id in unmapped_apiv1_elements:
+            unmapped_api_elements.append(f"-|`{element_id}`||")
+        unmapped_apiv2_elements = self._get_unmapped_api_elements_as_string(apiv2, print_for_apiv2=True)
+        for element_id in unmapped_apiv2_elements:
+            unmapped_api_elements.append(f"-||`{element_id}`|")
+        return unmapped_api_elements
 
-    def _get_not_mapped_api_elements_as_string(self, api: API, print_for_apiv2: bool = False) -> list[str]:
-        not_mapped_api_elements: list[str] = []
+    def _get_unmapped_api_elements_as_string(self, api: API, print_for_apiv2: bool = False) -> list[str]:
+        unmapped_api_elements: list[str] = []
 
         def is_included(api_element: Attribute | Class | Function | Parameter | Result) -> bool:
             if not print_for_apiv2:
@@ -216,29 +216,29 @@ class Migration:
 
         for class_ in api.classes.values():
             if not is_included(class_):
-                not_mapped_api_elements.append(class_.id)
+                unmapped_api_elements.append(class_.id)
         for function in api.functions.values():
             if not is_included(function):
-                not_mapped_api_elements.append(function.id)
+                unmapped_api_elements.append(function.id)
         for parameter in api.parameters().values():
             if not is_included(parameter):
-                not_mapped_api_elements.append(parameter.id)
+                unmapped_api_elements.append(parameter.id)
         for attribute, class_ in [
             (attribute, class_1) for class_1 in api.classes.values() for attribute in class_1.instance_attributes
         ]:
             if not is_included(attribute):
-                not_mapped_api_elements.append(class_.id + "/" + attribute.name)
+                unmapped_api_elements.append(class_.id + "/" + attribute.name)
         for result, function in [
             (result, function_1) for function_1 in api.functions.values() for result in function_1.results
         ]:
             if not is_included(result):
-                not_mapped_api_elements.append(function.id + "/" + result.name)
-        return not_mapped_api_elements
+                unmapped_api_elements.append(function.id + "/" + result.name)
+        return unmapped_api_elements
 
     def print(self, apiv1: API, apiv2: API) -> None:
         print("**Similarity**|**APIV1**|**APIV2**|**comment**\n:-----:|:-----:|:-----:|:----:|")
         table_body = self._get_mappings_for_table()
-        table_body.extend(self._get_not_mapped_api_elements_for_table(apiv1, apiv2))
+        table_body.extend(self._get_unmapped_api_elements_for_table(apiv1, apiv2))
         table_body.sort(key=lambda row: max(len(cell.split("/")) for cell in row.split("|")[:-1]))
         print("\n".join(table_body))
 

--- a/src/library_analyzer/processing/migration/_migrate.py
+++ b/src/library_analyzer/processing/migration/_migrate.py
@@ -157,83 +157,29 @@ class Migration:
         return unmapped_api_elements
 
     def _get_unmapped_api_elements_as_string(self, api: API, print_for_apiv2: bool = False) -> list[str]:
-        unmapped_api_elements: list[str] = []
+        api_elements: list[str] = []
+        for class_ in api.classes.values():
+            api_elements.append(class_.id)
+            for attribute in class_.instance_attributes:
+                api_elements.append(attribute.id)
+        for function in api.functions.values():
+            api_elements.append(function.id)
+            for result in function.results:
+                api_elements.append(result.id)
+        for parameter in api.parameters().values():
+            api_elements.append(parameter.id)
 
-        def is_included(api_element: Attribute | Class | Function | Parameter | Result) -> bool:
-            if not print_for_apiv2:
-                for mapping in self.mappings:
-                    for element in mapping.get_apiv1_elements():
-                        if (
-                            isinstance(api_element, Attribute)
-                            and isinstance(element, Attribute)
-                            and element.name == api_element.name
-                            and isinstance(element.types, type(api_element.types))
-                        ):
-                            return True
-                        if (
-                            isinstance(api_element, Result)
-                            and isinstance(element, Result)
-                            and element.name == api_element.name
-                            and element.docstring == api_element.docstring
-                        ):
-                            return True
-                        if (
-                            not isinstance(api_element, Attribute | Result)
-                            and not isinstance(
-                                element,
-                                Attribute | Result,
-                            )
-                            and element.id == api_element.id
-                        ):
-                            return True
-                return False
+        mapped_api_elements: set[str] = set()
+        if print_for_apiv2:
             for mapping in self.mappings:
                 for element in mapping.get_apiv2_elements():
-                    if (
-                        isinstance(api_element, Attribute)
-                        and isinstance(element, Attribute)
-                        and element.name == api_element.name
-                        and isinstance(element.types, type(api_element.types))
-                    ):
-                        return True
-                    if (
-                        isinstance(api_element, Result)
-                        and isinstance(element, Result)
-                        and element.name == api_element.name
-                        and element.docstring == api_element.docstring
-                    ):
-                        return True
-                    if (
-                        not isinstance(api_element, Attribute | Result)
-                        and not isinstance(
-                            element,
-                            Attribute | Result,
-                        )
-                        and element.id == api_element.id
-                    ):
-                        return True
-            return False
+                    mapped_api_elements.add(element.id)
+        else:
+            for mapping in self.mappings:
+                for element in mapping.get_apiv1_elements():
+                    mapped_api_elements.add(element.id)
 
-        for class_ in api.classes.values():
-            if not is_included(class_):
-                unmapped_api_elements.append(class_.id)
-        for function in api.functions.values():
-            if not is_included(function):
-                unmapped_api_elements.append(function.id)
-        for parameter in api.parameters().values():
-            if not is_included(parameter):
-                unmapped_api_elements.append(parameter.id)
-        for attribute, class_ in [
-            (attribute, class_1) for class_1 in api.classes.values() for attribute in class_1.instance_attributes
-        ]:
-            if not is_included(attribute):
-                unmapped_api_elements.append(class_.id + "/" + attribute.name)
-        for result, function in [
-            (result, function_1) for function_1 in api.functions.values() for result in function_1.results
-        ]:
-            if not is_included(result):
-                unmapped_api_elements.append(function.id + "/" + result.name)
-        return unmapped_api_elements
+        return [element for element in api_elements if element not in mapped_api_elements]
 
     def print(self, apiv1: API, apiv2: API) -> None:
         print("**Similarity**|**APIV1**|**APIV2**|**comment**\n:-----:|:-----:|:-----:|:----:|")

--- a/src/library_analyzer/processing/migration/model/_differ.py
+++ b/src/library_analyzer/processing/migration/model/_differ.py
@@ -22,7 +22,7 @@ from library_analyzer.processing.api.model import (
     UnionType,
 )
 
-from ._get_not_mapped_api_elements import _get_not_mapped_api_elements
+from ._get_unmapped_api_elements import _get_unmapped_api_elements
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
@@ -228,7 +228,7 @@ class SimpleDiffer(AbstractDiffer):
         apiv2: API,
     ) -> None:
         super().__init__(previous_base_differ, previous_mappings, apiv1, apiv2)
-        self.related_mappings = _get_not_mapped_api_elements(self.previous_mappings, self.apiv1, self.apiv2)
+        self.related_mappings = _get_unmapped_api_elements(self.previous_mappings, self.apiv1, self.apiv2)
         distance_between_implicit_and_explicit = 0.3
         distance_between_vararg_and_normal = 0.3
         distance_between_position_and_named = 0.3

--- a/src/library_analyzer/processing/migration/model/_get_unmapped_api_elements.py
+++ b/src/library_analyzer/processing/migration/model/_get_unmapped_api_elements.py
@@ -15,7 +15,7 @@ from ._mapping import ManyToManyMapping, Mapping
 api_element = Union[Attribute, Class, Function, Parameter, Result]
 
 
-def _get_not_mapped_api_elements(previous_mappings: list[Mapping], apiv1: API, apiv2: API) -> list[Mapping]:
+def _get_unmapped_api_elements(previous_mappings: list[Mapping], apiv1: API, apiv2: API) -> list[Mapping]:
     related_mappings = []
     mapped_apiv1_elements = [element for mapping in previous_mappings for element in mapping.get_apiv1_elements()]
     mapped_apiv2_elements = [element for mapping in previous_mappings for element in mapping.get_apiv2_elements()]
@@ -26,33 +26,33 @@ def _get_not_mapped_api_elements(previous_mappings: list[Mapping], apiv1: API, a
         lambda api: api.parameters().values(),
         lambda api: api.results().values(),
     ]:
-        not_mapped_elements_mapping = _get_not_mapped_api_elements_for_type(
+        unmapped_elements_mapping = _get_unmapped_api_elements_for_type(
             apiv1,
             apiv2,
             mapped_apiv1_elements,
             mapped_apiv2_elements,
             get_api_element_for_type,
         )
-        if not_mapped_elements_mapping is not None:
-            related_mappings.append(not_mapped_elements_mapping)
+        if unmapped_elements_mapping is not None:
+            related_mappings.append(unmapped_elements_mapping)
     return related_mappings
 
 
-def _get_not_mapped_api_elements_for_type(
+def _get_unmapped_api_elements_for_type(
     apiv1: API,
     apiv2: API,
     mapped_apiv1_elements: list[api_element],
     mapped_apiv2_elements: list[api_element],
     get_api_element_for_type: Callable[[API], list[api_element]],
 ) -> Mapping | None:
-    not_mapped_v1_elements = []
+    unmapped_v1_elements = []
     for api_elementv1 in get_api_element_for_type(apiv1):
         if api_elementv1 not in mapped_apiv1_elements:
-            not_mapped_v1_elements.append(api_elementv1)
-    not_mapped_v2_elements = []
+            unmapped_v1_elements.append(api_elementv1)
+    unmapped_v2_elements = []
     for api_elementv2 in get_api_element_for_type(apiv2):
         if api_elementv2 not in mapped_apiv2_elements:
-            not_mapped_v2_elements.append(api_elementv2)
-    if len(not_mapped_v1_elements) > 0 and len(not_mapped_v2_elements) > 0:
-        return ManyToManyMapping(-1.0, not_mapped_v1_elements, not_mapped_v2_elements)
+            unmapped_v2_elements.append(api_elementv2)
+    if len(unmapped_v1_elements) > 0 and len(unmapped_v2_elements) > 0:
+        return ManyToManyMapping(-1.0, unmapped_v1_elements, unmapped_v2_elements)
     return None

--- a/src/library_analyzer/processing/migration/model/_inheritance_differ.py
+++ b/src/library_analyzer/processing/migration/model/_inheritance_differ.py
@@ -10,7 +10,7 @@ from library_analyzer.processing.api.model import (
 )
 
 from ._differ import AbstractDiffer
-from ._get_not_mapped_api_elements import _get_not_mapped_api_elements
+from ._get_unmapped_api_elements import _get_unmapped_api_elements
 from ._mapping import Mapping
 
 api_element = Union[Attribute, Class, Function, Parameter, Result]
@@ -35,7 +35,7 @@ class InheritanceDiffer(AbstractDiffer):
         self.boost_value = boost_value
         self.inheritance = {}
         self.new_mappings = []
-        self.related_mappings = _get_not_mapped_api_elements(self.previous_mappings, self.apiv1, self.apiv2)
+        self.related_mappings = _get_unmapped_api_elements(self.previous_mappings, self.apiv1, self.apiv2)
         for class_v2 in self.apiv2.classes.values():
             additional_v1_elements = []
             for mapping in previous_mappings:


### PR DESCRIPTION
### Summary of Changes

Reduce the runtime of the migration script on the API data for the `library-analyzer` itself from 12.1s to 7.7s. For larger libraries the improvement should be more pronounced still.
