### PR TITLE
feat: extraction of boundary types from various docstrings

### DIFF
--- a/src/library_analyzer/processing/api/_extract_boundary_values.py
+++ b/src/library_analyzer/processing/api/_extract_boundary_values.py
@@ -170,7 +170,7 @@ _boundary_interval_in_brackets = [
     {"ORTH": ","},
     {},
     {"ORTH": {"IN": [")", "]"]}},
-    {"ORTH": ")"}
+    {"ORTH": ")"},
 ]
 
 
@@ -232,6 +232,7 @@ def _check_positive_pattern(
         matches.remove(matches[i])
 
     return None
+
 
 def _check_interval_relational_pattern(
     matcher: Matcher,  # noqa: ARG001
@@ -628,7 +629,6 @@ def _create_interval_in_brackets_boundary(match_string: Span, type_: str) -> Bou
     return _create_interval_boundary(span_, type_)
 
 
-
 def _analyze_matches(matches: list[tuple[str, Span]], boundaries: BoundaryList) -> None:
     """Analyze the passed match list for boundaries to be created.
 
@@ -648,7 +648,6 @@ def _analyze_matches(matches: list[tuple[str, Span]], boundaries: BoundaryList) 
 
     # Assignment of the found boundaries to the corresponding data type
     for match_label, match_string in matches:
-
         if match_label == "BOUNDARY_TYPE":
             if found_type:
                 other_id += 1

--- a/tests/library_analyzer/processing/api/test_extract_boundary_values.py
+++ b/tests/library_analyzer/processing/api/test_extract_boundary_values.py
@@ -69,10 +69,12 @@ BoundaryValueType = tuple[str, tuple[_Numeric | str, bool], tuple[_Numeric | str
         ),
         (
             "float between 0 and 1",
-            "Determines the minimum steepness on the reachability plot that constitutes a cluster boundary. For "
-            "example, an upwards point in the reachability plot is defined by the ratio from one point to its "
-            "successor being at most 1-xi. Used only when cluster_method='xi'.",
-            [("float", (0.0, True), (1.0, True))]
+            (
+                "Determines the minimum steepness on the reachability plot that constitutes a cluster boundary. For "
+                "example, an upwards point in the reachability plot is defined by the ratio from one point to its "
+                "successor being at most 1-xi. Used only when cluster_method='xi'."
+            ),
+            [("float", (0.0, True), (1.0, True))],
         ),
         (
             "float",
@@ -212,8 +214,8 @@ BoundaryValueType = tuple[str, tuple[_Numeric | str, bool], tuple[_Numeric | str
                 " decision_function_shape is 'ovr' by default.\n\n.. versionadded: 0.17 decision_function_shape='ovr'"
                 " is recommended.\n\n.. versionchanged: 0.17 Deprecated decision_function_shape='ovo' and None."
             ),
-            []
-        )
+            [],
+        ),
     ],
 )
 def test_extract_boundaries(type_string: str, description: str, expected_boundary: list[BoundaryValueType]) -> None:


### PR DESCRIPTION
Closes #48, closes #36, closes #35, closes #32, closes #31, closes #30, closes #27, closes #8.
 

### Summary of Changes

SpaCy rules were generated to recognize named examples and extract the resulting boundaries. 

### Instructions for Manual Testing (if required)

1. Run `pytest` for `test_extract_boundary_values.py`.
2. Check the results of `pytest`.
